### PR TITLE
Customize MKCoordinateSpan in MapSnapManager

### DIFF
--- a/MapSnap/Classes/MKMapSnapshotter+MapSnap.swift
+++ b/MapSnap/Classes/MKMapSnapshotter+MapSnap.swift
@@ -11,8 +11,8 @@ import MapKit
 public typealias MapSnapshotterCompletion = (UIImage?, NSError?) -> Void
 
 public extension MKMapSnapshotter {
-    static func image(for coordinate: CLLocationCoordinate2D, size: CGSize, completion: MapSnapshotterCompletion?) {
-        let span = MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
+    static func image(for coordinate: CLLocationCoordinate2D, size: CGSize, span: MKCoordinateSpan, completion: MapSnapshotterCompletion?) {
+        
         let region = MKCoordinateRegion(center: coordinate, span: span)
         
         let options = MKMapSnapshotOptions()

--- a/MapSnap/Classes/MapSnapManager.swift
+++ b/MapSnap/Classes/MapSnapManager.swift
@@ -16,6 +16,7 @@ open class MapSnapManager {
     
     open var defaultImageSize = CGSize(width: UIScreen.main.bounds.width, height: 150.0)
     open var cache: MapSnapCache?
+    open var defaultMapSpan = MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
     
     fileprivate var pendingOperationIDs = [UUID]()
 }
@@ -31,9 +32,10 @@ public extension MapSnapManager {
         pendingOperationIDs.remove(at: index)
     }
     
-    func image(for coordinate: CLLocationCoordinate2D, size: CGSize? = nil, completion: MapSnapImageCompletion?) -> UUID? {
+    func image(for coordinate: CLLocationCoordinate2D, size: CGSize? = nil, span: MKCoordinateSpan? = nil, completion: MapSnapImageCompletion?) -> UUID? {
         let cache = self.cache ?? PINCache.shared()
         let imageSize = size ?? defaultImageSize
+        let mapSpan = span ?? defaultMapSpan
         
         let key = [
             String(describing: coordinate),
@@ -64,7 +66,7 @@ public extension MapSnapManager {
             
             pendingOperationIDs.append(operationID)
             
-            MKMapSnapshotter.image(for: coordinate, size: imageSize, completion: snapshotCompletion)
+            MKMapSnapshotter.image(for: coordinate, size: imageSize, span: mapSpan, completion: snapshotCompletion)
             
             return operationID
         }


### PR DESCRIPTION
Added defaultMapSpan var in MapSnapManager to allow changes on the map coordinate span. 
Default value is same as before. 

(Part of issue #1)